### PR TITLE
chore(manifest): added ox_lib dependancy

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -25,3 +25,7 @@ files {
     "locales/*.json",
     "modules/*.lua"
 }
+
+dependencies {
+    "ox_lib"
+}


### PR DESCRIPTION
Makes sure people can't start it without it.